### PR TITLE
Compatible with low version, eg:2.0

### DIFF
--- a/JSQSystemSoundPlayer/JSQSystemSoundPlayer/JSQSystemSoundPlayer.h
+++ b/JSQSystemSoundPlayer/JSQSystemSoundPlayer/JSQSystemSoundPlayer.h
@@ -116,6 +116,42 @@ typedef void(^JSQSystemSoundPlayerCompletionBlock)(void);
  @warning Disabling the sound player (passing a value of `NO`) will invoke the `stopAllSounds` method.
  */
 - (void)toggleSoundPlayerOn:(BOOL)on;
+/**
+ Plays a system sound object corresponding to an audio file with the given filename and extension,
+ and excutes `completionBlock` when the sound has stopped playing.
+ The system sound player will lazily initialize and load the file before playing it, and then cache its corresponding `SystemSoundID`.
+ If this file has previously been played, it will be loaded from cache and played immediately.
+ 
+ @param filename        A string containing the base name of the audio file to play.
+ @param fileExtension   A string containing the extension of the audio file to play.
+ This block is retained by `JSQSystemSoundPlayer`, temporarily cached, and released after its execution. This value may be `nil`.
+ 
+ @note The fileExtension parameter must be one of `kJSQSystemSoundTypeCAF`, `kJSQSystemSoundTypeAIF`,
+ `kJSQSystemSoundTypeAIFF`, or `kJSQSystemSoundTypeWAV`.
+ 
+ @warning If the system sound object cannot be created, this method does nothing.
+ */
+- (void)playSoundWithFilename:(NSString *)filename
+                fileExtension:(NSString *)fileExtension;
+/**
+ Plays a system sound object corresponding to an audio file with the given filename and extension,
+ and excutes `completionBlock` when the sound has stopped playing.
+ The system sound player will lazily initialize and load the file before playing it, and then cache its corresponding `SystemSoundID`.
+ If this file has previously been played, it will be loaded from cache and played immediately.
+ 
+ @param filename        A string containing the base name of the audio file to play.
+ @param fileExtension   A string containing the extension of the audio file to play.
+ @param isAlert
+ This block is retained by `JSQSystemSoundPlayer`, temporarily cached, and released after its execution. This value may be `nil`.
+ 
+ @note The fileExtension parameter must be one of `kJSQSystemSoundTypeCAF`, `kJSQSystemSoundTypeAIF`,
+ `kJSQSystemSoundTypeAIFF`, or `kJSQSystemSoundTypeWAV`.
+ 
+ @warning If the system sound object cannot be created, this method does nothing.
+ */
+- (void)playSoundWithFilename:(NSString *)filename
+                fileExtension:(NSString *)fileExtension
+                   isAlert:(BOOL)isAlert;
 
 /**
  Plays a system sound object corresponding to an audio file with the given filename and extension,

--- a/JSQSystemSoundPlayer/JSQSystemSoundPlayer/JSQSystemSoundPlayer.m
+++ b/JSQSystemSoundPlayer/JSQSystemSoundPlayer/JSQSystemSoundPlayer.m
@@ -121,6 +121,18 @@ static void systemServicesSoundCompletion(SystemSoundID  soundID, void *data)
 
 
 #pragma mark - Playing sounds
+- (void)playSoundWithName:(NSString *)filename
+                extension:(NSString *)extension
+{
+    [self playSoundWithName:filename extension:extension isAlert:NO completionBlock:nil];
+}
+
+- (void)playSoundWithName:(NSString *)filename
+                extension:(NSString *)extension
+                  isAlert:(BOOL)isAlert
+{
+    [self playSoundWithName:filename extension:extension isAlert:isAlert completionBlock:nil];
+}
 
 - (void)playSoundWithName:(NSString *)filename
                 extension:(NSString *)extension


### PR DESCRIPTION
Compatible with low version, eg:2.0
when i use  JSQMessagesViewController ,i find it use version 2.0,and it still use old interface ,so add two interface to Compatible with low version.